### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,31 +6,31 @@
 # Class (KEYWORD1)
 #######################################
 
-CayenneLPP            KEYWORD1 CayenneLPP
+CayenneLPP	KEYWORD1	CayenneLPP
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-reset                 KEYWORD2
-getSize               KEYWORD2
-*getBuffer            KEYWORD2
-copy                  KEYWORD2
+reset	KEYWORD2
+getSize	KEYWORD2
+*getBuffer	KEYWORD2
+copy	KEYWORD2
 
-addDigitalInput       KEYWORD2
-addDigitalOutput      KEYWORD2
+addDigitalInput	KEYWORD2
+addDigitalOutput	KEYWORD2
 
-addAnalogInput        KEYWORD2
-addAnalogOutput       KEYWORD2
+addAnalogInput	KEYWORD2
+addAnalogOutput	KEYWORD2
 
-addLuminosity         KEYWORD2
-addPresence           KEYWORD2
-addTemperature        KEYWORD2
-addRelativeHumidity   KEYWORD2
-addAccelerometer      KEYWORD2
-addBarometricPressure KEYWORD2
-addGyrometer          KEYWORD2
-addGPS                KEYWORD2
+addLuminosity	KEYWORD2
+addPresence	KEYWORD2
+addTemperature	KEYWORD2
+addRelativeHumidity	KEYWORD2
+addAccelerometer	KEYWORD2
+addBarometricPressure	KEYWORD2
+addGyrometer	KEYWORD2
+addGPS	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords